### PR TITLE
Fix getting wrong widget ID form hash if hash string is including slash

### DIFF
--- a/src/workbench-widget-api.js
+++ b/src/workbench-widget-api.js
@@ -574,7 +574,7 @@
   }
 
   function _getIdFromHash() {
-    return decodeURIComponent(window.location.hash.substr(1).replace(/\+/g, " "));
+    return decodeURIComponent(window.location.hash.substr(1).replace(/^\//, '').replace(/\+/g, " "));
   }
 
   function _logMessage() {


### PR DESCRIPTION
Recently I noticed `widget-api.js` makes wrong widget id if widget html has a routing by using typical SPA framework like react, and routing is based on hash string.

For example,  If widget html is served from `https://example.com/#/search/concepts/example`, `_getIdFromHash` would return `/search/concepts/example`. But parent frame expect `search/concepts/example` as a widget id and verifying would fail. After that, child frame can not receive a message from parent frame, that means promise wouldn't be resolved or rejected. 

I don't understand widget framework itself and messaging passing between parent frame and widget so much. If this change does not make sense, please ignore.