### PR TITLE
Support for KMM events

### DIFF
--- a/doc/ApiDocumentation/README.md
+++ b/doc/ApiDocumentation/README.md
@@ -10,6 +10,12 @@
 
 * [WorkbenchWidgetApi](classes/workbenchwidgetapi.md)
 
+### Other Type aliases
+
+* [EventListener](README.md#eventlistener)
+* [KmmEvent](README.md#kmmevent)
+* [KmmEventType](README.md#kmmeventtype)
+
 ### Widget Api Type aliases
 
 * [LabelEditFormData](README.md#labeleditformdata)
@@ -21,13 +27,55 @@
 * [decycle](README.md#decycle)
 * [retrocycle](README.md#retrocycle)
 
+## Other Type aliases
+
+### EventListener
+
+Ƭ  **EventListener**: (data: [KmmEvent](README.md#kmmevent)) => void
+
+*Defined in [src/workbench-widget-api.ts:44](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L44)*
+
+General type of an event listener.
+
+**`see`** [WorkbenchWidgetApi.addEventListener](classes/workbenchwidgetapi.md#addeventlistener)
+
+___
+
+### KmmEvent
+
+Ƭ  **KmmEvent**: { type: \"CONCEPT\_UPDATED\"  }
+
+*Defined in [src/workbench-widget-api.ts:32](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L32)*
+
+Type of event that KMM application can broadcast to widgets.
+
+Widgets can register to listen to specyfic event using
+
+#### Type declaration:
+
+Name | Type |
+------ | ------ |
+`type` | \"CONCEPT\_UPDATED\" |
+
+___
+
+### KmmEventType
+
+Ƭ  **KmmEventType**: Pick\<KmmEvent, \"type\">[\"type\"]
+
+*Defined in [src/workbench-widget-api.ts:38](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L38)*
+
+All event types users can listen for.
+
+___
+
 ## Widget Api Type aliases
 
 ### LabelEditFormData
 
 Ƭ  **LabelEditFormData**: { config: [LabelFormConfig](README.md#labelformconfig) ; data: [LabelFormValue](README.md#labelformvalue)  }
 
-*Defined in [src/workbench-widget-api.ts:55](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/b6b1358/src/workbench-widget-api.ts#L55)*
+*Defined in [src/workbench-widget-api.ts:79](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L79)*
 
 Data transfer type for sending information about editing single label (alt or pref).
 Used in [showFormAddMultipleTranslation](classes/workbenchwidgetapi.md#showformaddmultipletranslation)
@@ -45,7 +93,7 @@ ___
 
 Ƭ  **LabelFormConfig**: { editableLanguage: boolean ; editableType: boolean  }
 
-*Defined in [src/workbench-widget-api.ts:42](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/b6b1358/src/workbench-widget-api.ts#L42)*
+*Defined in [src/workbench-widget-api.ts:66](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L66)*
 
 #### Type declaration:
 
@@ -60,7 +108,7 @@ ___
 
 Ƭ  **LabelFormValue**: { labelLanguage: string ; labelValue: string ; typeUri: string  }
 
-*Defined in [src/workbench-widget-api.ts:30](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/b6b1358/src/workbench-widget-api.ts#L30)*
+*Defined in [src/workbench-widget-api.ts:54](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L54)*
 
 #### Type declaration:
 
@@ -76,7 +124,7 @@ Name | Type | Description |
 
 ▸ **decycle**(`object`: any): any
 
-*Defined in [src/cycle.ts:24](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/b6b1358/src/cycle.ts#L24)*
+*Defined in [src/cycle.ts:24](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/cycle.ts#L24)*
 
 Make a deep copy of an object or array, assuring that there is at most
 one instance of each object or array in the resulting structure. The
@@ -112,7 +160,7 @@ ___
 
 ▸ **retrocycle**(`$`: any): any
 
-*Defined in [src/cycle.ts:110](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/b6b1358/src/cycle.ts#L110)*
+*Defined in [src/cycle.ts:110](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/cycle.ts#L110)*
 
 Restore an object that was reduced by decycle. Members whose values are
 objects of the form `{$ref: PATH}` are replaced with references to the

--- a/doc/ApiDocumentation/README.md
+++ b/doc/ApiDocumentation/README.md
@@ -10,13 +10,13 @@
 
 * [WorkbenchWidgetApi](classes/workbenchwidgetapi.md)
 
-### Other Type aliases
+### KMM Messaging Type aliases
 
 * [EventListener](README.md#eventlistener)
 * [KmmEvent](README.md#kmmevent)
 * [KmmEventType](README.md#kmmeventtype)
 
-### Widget Api Type aliases
+### KMM action parameters Type aliases
 
 * [LabelEditFormData](README.md#labeleditformdata)
 * [LabelFormConfig](README.md#labelformconfig)
@@ -27,13 +27,13 @@
 * [decycle](README.md#decycle)
 * [retrocycle](README.md#retrocycle)
 
-## Other Type aliases
+## KMM Messaging Type aliases
 
 ### EventListener
 
 Ƭ  **EventListener**: (data: [KmmEvent](README.md#kmmevent)) => void
 
-*Defined in [src/workbench-widget-api.ts:44](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L44)*
+*Defined in [src/workbench-widget-api.ts:65](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L65)*
 
 General type of an event listener.
 
@@ -43,39 +43,33 @@ ___
 
 ### KmmEvent
 
-Ƭ  **KmmEvent**: { type: \"CONCEPT\_UPDATED\"  }
+Ƭ  **KmmEvent**: { type: \"CONCEPT\_UPDATED\"  } \| { type: \"CONCEPT\_SCHEME\_UPDATED\"  }
 
-*Defined in [src/workbench-widget-api.ts:32](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L32)*
+*Defined in [src/workbench-widget-api.ts:46](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L46)*
 
 Type of event that KMM application can broadcast to widgets.
 
 Widgets can register to listen to specyfic event using
 
-#### Type declaration:
-
-Name | Type |
------- | ------ |
-`type` | \"CONCEPT\_UPDATED\" |
-
 ___
 
 ### KmmEventType
 
-Ƭ  **KmmEventType**: Pick\<KmmEvent, \"type\">[\"type\"]
+Ƭ  **KmmEventType**: \"CONCEPT\_UPDATED\" \| \"CONCEPT\_SCHEME\_UPDATED\"
 
-*Defined in [src/workbench-widget-api.ts:38](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L38)*
+*Defined in [src/workbench-widget-api.ts:58](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L58)*
 
 All event types users can listen for.
 
 ___
 
-## Widget Api Type aliases
+## KMM action parameters Type aliases
 
 ### LabelEditFormData
 
 Ƭ  **LabelEditFormData**: { config: [LabelFormConfig](README.md#labelformconfig) ; data: [LabelFormValue](README.md#labelformvalue)  }
 
-*Defined in [src/workbench-widget-api.ts:79](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L79)*
+*Defined in [src/workbench-widget-api.ts:109](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L109)*
 
 Data transfer type for sending information about editing single label (alt or pref).
 Used in [showFormAddMultipleTranslation](classes/workbenchwidgetapi.md#showformaddmultipletranslation)
@@ -93,7 +87,7 @@ ___
 
 Ƭ  **LabelFormConfig**: { editableLanguage: boolean ; editableType: boolean  }
 
-*Defined in [src/workbench-widget-api.ts:66](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L66)*
+*Defined in [src/workbench-widget-api.ts:96](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L96)*
 
 #### Type declaration:
 
@@ -108,7 +102,7 @@ ___
 
 Ƭ  **LabelFormValue**: { labelLanguage: string ; labelValue: string ; typeUri: string  }
 
-*Defined in [src/workbench-widget-api.ts:54](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L54)*
+*Defined in [src/workbench-widget-api.ts:84](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L84)*
 
 #### Type declaration:
 
@@ -124,7 +118,7 @@ Name | Type | Description |
 
 ▸ **decycle**(`object`: any): any
 
-*Defined in [src/cycle.ts:24](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/cycle.ts#L24)*
+*Defined in [src/cycle.ts:24](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/cycle.ts#L24)*
 
 Make a deep copy of an object or array, assuring that there is at most
 one instance of each object or array in the resulting structure. The
@@ -160,7 +154,7 @@ ___
 
 ▸ **retrocycle**(`$`: any): any
 
-*Defined in [src/cycle.ts:110](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/cycle.ts#L110)*
+*Defined in [src/cycle.ts:110](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/cycle.ts#L110)*
 
 Restore an object that was reduced by decycle. Members whose values are
 objects of the form `{$ref: PATH}` are replaced with references to the

--- a/doc/ApiDocumentation/classes/workbenchwidgetapi.md
+++ b/doc/ApiDocumentation/classes/workbenchwidgetapi.md
@@ -54,28 +54,15 @@
 
 ### constructor
 
-\+ **new WorkbenchWidgetApi**(`debug?`: undefined \| false \| true): [WorkbenchWidgetApi](workbenchwidgetapi.md)
+\+ **new WorkbenchWidgetApi**(`debug?`: boolean): [WorkbenchWidgetApi](workbenchwidgetapi.md)
 
-*Defined in [src/workbench-widget-api.ts:92](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L92)*
-
-#### Parameters:
-
-Name | Type | Description |
------- | ------ | ------ |
-`debug?` | undefined \| false \| true | If set to true additional debug messages will be logged to console  |
-
-**Returns:** [WorkbenchWidgetApi](workbenchwidgetapi.md)
-
-\+ **new WorkbenchWidgetApi**(`widgetId?`: undefined \| string, `debug?`: undefined \| false \| true): [WorkbenchWidgetApi](workbenchwidgetapi.md)
-
-*Defined in [src/workbench-widget-api.ts:97](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L97)*
+*Defined in [src/workbench-widget-api.ts:120](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L120)*
 
 #### Parameters:
 
-Name | Type | Description |
------- | ------ | ------ |
-`widgetId?` | undefined \| string | - |
-`debug?` | undefined \| false \| true | If set to true additional debug messages will be logged to console  |
+Name | Type | Default value | Description |
+------ | ------ | ------ | ------ |
+`debug` | boolean | false | If set to true additional debug messages will be logged to console  |
 
 **Returns:** [WorkbenchWidgetApi](workbenchwidgetapi.md)
 
@@ -85,16 +72,20 @@ Name | Type | Description |
 
 ▸ **addEventListener**(`type`: [KmmEventType](../README.md#kmmeventtype), `listener`: [EventListener](../README.md#eventlistener)): function
 
-*Defined in [src/workbench-widget-api.ts:115](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L115)*
+*Defined in [src/workbench-widget-api.ts:136](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L136)*
+
+Registers a new listener for KMM events.
 
 #### Parameters:
 
-Name | Type |
------- | ------ |
-`type` | [KmmEventType](../README.md#kmmeventtype) |
-`listener` | [EventListener](../README.md#eventlistener) |
+Name | Type | Description |
+------ | ------ | ------ |
+`type` | [KmmEventType](../README.md#kmmeventtype) | Which event to listen for |
+`listener` | [EventListener](../README.md#eventlistener) | Callback function that will be called with event data every time an event of type `type` will be received |
 
 **Returns:** function
+
+Deregistering function; when invoked removes this event listener.
 
 ___
 
@@ -102,7 +93,7 @@ ___
 
 ▸ **closeWidget**(): Promise\<void>
 
-*Defined in [src/workbench-widget-api.ts:149](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L149)*
+*Defined in [src/workbench-widget-api.ts:170](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L170)*
 
 Close right side panel in host application.
 
@@ -114,7 +105,7 @@ ___
 
 ▸ **getAltLabelProperties**(`taskGraphUri`: string, `itemUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:262](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L262)*
+*Defined in [src/workbench-widget-api.ts:283](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L283)*
 
 Return Alternative Labels Types valid for item.
 
@@ -133,7 +124,7 @@ ___
 
 ▸ **getAltLabelUnfilteredProperties**(`taskGraphUri`: string, `itemUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:251](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L251)*
+*Defined in [src/workbench-widget-api.ts:272](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L272)*
 
 Return All Alternative Labels Types.
 
@@ -152,7 +143,7 @@ ___
 
 ▸ **getAssociativeTypes**(`taskGraphUri`: string, `itemUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:184](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L184)*
+*Defined in [src/workbench-widget-api.ts:205](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L205)*
 
 Return Associative Types valid for current item.
 
@@ -171,7 +162,7 @@ ___
 
 ▸ **getAssociativeUnfilteredTypes**(`taskGraphUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:172](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L172)*
+*Defined in [src/workbench-widget-api.ts:193](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L193)*
 
 Return all Associative Types.
 
@@ -189,7 +180,7 @@ ___
 
 ▸ **getBroaderTypes**(`taskGraphUri`: string, `itemUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:205](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L205)*
+*Defined in [src/workbench-widget-api.ts:226](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L226)*
 
 Return Broader Types valid for current item.
 
@@ -208,7 +199,7 @@ ___
 
 ▸ **getBroaderUnfilteredTypes**(`taskGraphUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:195](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L195)*
+*Defined in [src/workbench-widget-api.ts:216](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L216)*
 
 Return all Broader Types.
 
@@ -226,7 +217,7 @@ ___
 
 ▸ **getClasses**(`taskGraphUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:165](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L165)*
+*Defined in [src/workbench-widget-api.ts:186](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L186)*
 
 Return class data for current item.
 
@@ -244,7 +235,7 @@ ___
 
 ▸ **getConceptAltLabels**(`taskGraphUri`: string, `itemUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:357](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L357)*
+*Defined in [src/workbench-widget-api.ts:378](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L378)*
 
  Return concept details with alternative labels.
 
@@ -263,7 +254,7 @@ ___
 
 ▸ **getConceptBroader**(`taskGraphUri`: string, `itemUri`: string, `limit?`: number, `offset?`: number): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:404](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L404)*
+*Defined in [src/workbench-widget-api.ts:425](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L425)*
 
  Return concept details with broader concepts grouped by relation type.
 
@@ -284,7 +275,7 @@ ___
 
 ▸ **getConceptDetails**(`taskGraphUri`: string, `itemUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:324](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L324)*
+*Defined in [src/workbench-widget-api.ts:345](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L345)*
 
  Return concept details.
 
@@ -303,7 +294,7 @@ ___
 
 ▸ **getConceptGuid**(`taskGraphUri`: string, `itemUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:335](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L335)*
+*Defined in [src/workbench-widget-api.ts:356](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L356)*
 
  Return concept guid data.
 
@@ -322,7 +313,7 @@ ___
 
 ▸ **getConceptNarrower**(`taskGraphUri`: string, `itemUri`: string, `limit?`: number, `offset?`: number): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:386](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L386)*
+*Defined in [src/workbench-widget-api.ts:407](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L407)*
 
  Return concept details with narrower concepts grouped by relation type.
 
@@ -343,7 +334,7 @@ ___
 
 ▸ **getConceptPrefLabels**(`taskGraphUri`: string, `itemUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:346](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L346)*
+*Defined in [src/workbench-widget-api.ts:367](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L367)*
 
  Return concept details with preferred labels.
 
@@ -362,7 +353,7 @@ ___
 
 ▸ **getConceptRelated**(`taskGraphUri`: string, `itemUri`: string, `limit?`: number, `offset?`: number): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:368](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L368)*
+*Defined in [src/workbench-widget-api.ts:389](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L389)*
 
  Return concept details with associative concepts grouped by relation type.
 
@@ -383,7 +374,7 @@ ___
 
 ▸ **getConceptSchemes**(`taskGraphUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:317](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L317)*
+*Defined in [src/workbench-widget-api.ts:338](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L338)*
 
  Return all concept schemes for given task.
 
@@ -401,7 +392,7 @@ ___
 
 ▸ **getDetailsWithMetadata**(`taskGraphUri`: string, `itemUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:295](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L295)*
+*Defined in [src/workbench-widget-api.ts:316](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L316)*
 
 Return Item with metadata properties.
 
@@ -420,7 +411,7 @@ ___
 
 ▸ **getMetadataForDomain**(`taskGraphUri`: string, `domainUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:306](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L306)*
+*Defined in [src/workbench-widget-api.ts:327](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L327)*
 
  Return both default metadata and metadata specific for given domain.
 
@@ -439,7 +430,7 @@ ___
 
 ▸ **getMetadataTypes**(`taskGraphUri`: string, `itemUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:284](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L284)*
+*Defined in [src/workbench-widget-api.ts:305](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L305)*
 
 Return Metadata types valid for item.
 
@@ -458,7 +449,7 @@ ___
 
 ▸ **getMetadataUnfilteredTypes**(`taskGraphUri`: string, `itemUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:273](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L273)*
+*Defined in [src/workbench-widget-api.ts:294](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L294)*
 
 Return Metadata types.
 
@@ -477,7 +468,7 @@ ___
 
 ▸ **getModelLanguages**(`modelGraphUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:237](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L237)*
+*Defined in [src/workbench-widget-api.ts:258](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L258)*
 
 Return Languages valid for the model.
 
@@ -495,7 +486,7 @@ ___
 
 ▸ **getNarrowerTypes**(`taskGraphUri`: string, `itemUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:226](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L226)*
+*Defined in [src/workbench-widget-api.ts:247](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L247)*
 
 Return Narrower Types valid for current item.
 
@@ -514,7 +505,7 @@ ___
 
 ▸ **getNarrowerUnfilteredTypes**(`taskGraphUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:216](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L216)*
+*Defined in [src/workbench-widget-api.ts:237](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L237)*
 
 Return all Narrower Types.
 
@@ -532,7 +523,7 @@ ___
 
 ▸ **getSemaphoreSettings**(`taskGraphUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:244](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L244)*
+*Defined in [src/workbench-widget-api.ts:265](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L265)*
 
 Return Semaphore Settings.
 
@@ -550,7 +541,7 @@ ___
 
 ▸ **getStateParams**(): Promise\<{ itemUri?: undefined \| string ; modelGraphUri?: undefined \| string ; taskGraphUri?: undefined \| string  }>
 
-*Defined in [src/workbench-widget-api.ts:126](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L126)*
+*Defined in [src/workbench-widget-api.ts:147](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L147)*
 
 Fetch current host state params (modelGraphUri, taskGraphUri, itemUri).
 
@@ -562,7 +553,7 @@ ___
 
 ▸ **getTopConcepts**(`taskGraphUri`: string, `itemUri`: string, `limit?`: number, `offset?`: number): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:422](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L422)*
+*Defined in [src/workbench-widget-api.ts:443](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L443)*
 
  Return concept scheme details with top concepts.
 
@@ -583,7 +574,7 @@ ___
 
 ▸ **navigateToItem**(`item`: string): Promise\<void>
 
-*Defined in [src/workbench-widget-api.ts:139](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L139)*
+*Defined in [src/workbench-widget-api.ts:160](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L160)*
 
 Navigate host application to item.
 
@@ -601,7 +592,7 @@ ___
 
 ▸ **openWidget**(`targetWidgetId`: string): Promise\<void>
 
-*Defined in [src/workbench-widget-api.ts:157](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L157)*
+*Defined in [src/workbench-widget-api.ts:178](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L178)*
 
 Open different widget in the same model.
 
@@ -619,7 +610,7 @@ Name | Type |
 
 ▪  **actions**: object
 
-*Defined in [src/workbench-widget-api.ts:440](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L440)*
+*Defined in [src/workbench-widget-api.ts:461](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/4bbea95/src/workbench-widget-api.ts#L461)*
 
 Actions can be used to use Workbench functionality directly.
 

--- a/doc/ApiDocumentation/classes/workbenchwidgetapi.md
+++ b/doc/ApiDocumentation/classes/workbenchwidgetapi.md
@@ -16,6 +16,7 @@
 
 ### Methods
 
+* [addEventListener](workbenchwidgetapi.md#addeventlistener)
 * [closeWidget](workbenchwidgetapi.md#closewidget)
 * [getAltLabelProperties](workbenchwidgetapi.md#getaltlabelproperties)
 * [getAltLabelUnfilteredProperties](workbenchwidgetapi.md#getaltlabelunfilteredproperties)
@@ -53,26 +54,55 @@
 
 ### constructor
 
-\+ **new WorkbenchWidgetApi**(`widgetId?`: string, `debug?`: boolean): [WorkbenchWidgetApi](workbenchwidgetapi.md)
+\+ **new WorkbenchWidgetApi**(`debug?`: undefined \| false \| true): [WorkbenchWidgetApi](workbenchwidgetapi.md)
 
-*Defined in [src/workbench-widget-api.ts:64](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/b6b1358/src/workbench-widget-api.ts#L64)*
+*Defined in [src/workbench-widget-api.ts:92](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L92)*
 
 #### Parameters:
 
-Name | Type | Default value |
+Name | Type | Description |
 ------ | ------ | ------ |
-`widgetId` | string | DEFAULT\_WIDGET\_ID |
-`debug` | boolean | false |
+`debug?` | undefined \| false \| true | If set to true additional debug messages will be logged to console  |
+
+**Returns:** [WorkbenchWidgetApi](workbenchwidgetapi.md)
+
+\+ **new WorkbenchWidgetApi**(`widgetId?`: undefined \| string, `debug?`: undefined \| false \| true): [WorkbenchWidgetApi](workbenchwidgetapi.md)
+
+*Defined in [src/workbench-widget-api.ts:97](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L97)*
+
+#### Parameters:
+
+Name | Type | Description |
+------ | ------ | ------ |
+`widgetId?` | undefined \| string | - |
+`debug?` | undefined \| false \| true | If set to true additional debug messages will be logged to console  |
 
 **Returns:** [WorkbenchWidgetApi](workbenchwidgetapi.md)
 
 ## Methods
 
+### addEventListener
+
+▸ **addEventListener**(`type`: [KmmEventType](../README.md#kmmeventtype), `listener`: [EventListener](../README.md#eventlistener)): function
+
+*Defined in [src/workbench-widget-api.ts:115](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L115)*
+
+#### Parameters:
+
+Name | Type |
+------ | ------ |
+`type` | [KmmEventType](../README.md#kmmeventtype) |
+`listener` | [EventListener](../README.md#eventlistener) |
+
+**Returns:** function
+
+___
+
 ### closeWidget
 
 ▸ **closeWidget**(): Promise\<void>
 
-*Defined in [src/workbench-widget-api.ts:101](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/b6b1358/src/workbench-widget-api.ts#L101)*
+*Defined in [src/workbench-widget-api.ts:149](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L149)*
 
 Close right side panel in host application.
 
@@ -84,7 +114,7 @@ ___
 
 ▸ **getAltLabelProperties**(`taskGraphUri`: string, `itemUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:214](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/b6b1358/src/workbench-widget-api.ts#L214)*
+*Defined in [src/workbench-widget-api.ts:262](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L262)*
 
 Return Alternative Labels Types valid for item.
 
@@ -103,7 +133,7 @@ ___
 
 ▸ **getAltLabelUnfilteredProperties**(`taskGraphUri`: string, `itemUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:203](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/b6b1358/src/workbench-widget-api.ts#L203)*
+*Defined in [src/workbench-widget-api.ts:251](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L251)*
 
 Return All Alternative Labels Types.
 
@@ -122,7 +152,7 @@ ___
 
 ▸ **getAssociativeTypes**(`taskGraphUri`: string, `itemUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:136](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/b6b1358/src/workbench-widget-api.ts#L136)*
+*Defined in [src/workbench-widget-api.ts:184](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L184)*
 
 Return Associative Types valid for current item.
 
@@ -141,7 +171,7 @@ ___
 
 ▸ **getAssociativeUnfilteredTypes**(`taskGraphUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:124](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/b6b1358/src/workbench-widget-api.ts#L124)*
+*Defined in [src/workbench-widget-api.ts:172](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L172)*
 
 Return all Associative Types.
 
@@ -159,7 +189,7 @@ ___
 
 ▸ **getBroaderTypes**(`taskGraphUri`: string, `itemUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:157](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/b6b1358/src/workbench-widget-api.ts#L157)*
+*Defined in [src/workbench-widget-api.ts:205](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L205)*
 
 Return Broader Types valid for current item.
 
@@ -178,7 +208,7 @@ ___
 
 ▸ **getBroaderUnfilteredTypes**(`taskGraphUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:147](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/b6b1358/src/workbench-widget-api.ts#L147)*
+*Defined in [src/workbench-widget-api.ts:195](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L195)*
 
 Return all Broader Types.
 
@@ -196,7 +226,7 @@ ___
 
 ▸ **getClasses**(`taskGraphUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:117](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/b6b1358/src/workbench-widget-api.ts#L117)*
+*Defined in [src/workbench-widget-api.ts:165](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L165)*
 
 Return class data for current item.
 
@@ -214,7 +244,7 @@ ___
 
 ▸ **getConceptAltLabels**(`taskGraphUri`: string, `itemUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:309](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/b6b1358/src/workbench-widget-api.ts#L309)*
+*Defined in [src/workbench-widget-api.ts:357](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L357)*
 
  Return concept details with alternative labels.
 
@@ -233,7 +263,7 @@ ___
 
 ▸ **getConceptBroader**(`taskGraphUri`: string, `itemUri`: string, `limit?`: number, `offset?`: number): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:356](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/b6b1358/src/workbench-widget-api.ts#L356)*
+*Defined in [src/workbench-widget-api.ts:404](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L404)*
 
  Return concept details with broader concepts grouped by relation type.
 
@@ -254,7 +284,7 @@ ___
 
 ▸ **getConceptDetails**(`taskGraphUri`: string, `itemUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:276](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/b6b1358/src/workbench-widget-api.ts#L276)*
+*Defined in [src/workbench-widget-api.ts:324](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L324)*
 
  Return concept details.
 
@@ -273,7 +303,7 @@ ___
 
 ▸ **getConceptGuid**(`taskGraphUri`: string, `itemUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:287](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/b6b1358/src/workbench-widget-api.ts#L287)*
+*Defined in [src/workbench-widget-api.ts:335](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L335)*
 
  Return concept guid data.
 
@@ -292,7 +322,7 @@ ___
 
 ▸ **getConceptNarrower**(`taskGraphUri`: string, `itemUri`: string, `limit?`: number, `offset?`: number): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:338](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/b6b1358/src/workbench-widget-api.ts#L338)*
+*Defined in [src/workbench-widget-api.ts:386](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L386)*
 
  Return concept details with narrower concepts grouped by relation type.
 
@@ -313,7 +343,7 @@ ___
 
 ▸ **getConceptPrefLabels**(`taskGraphUri`: string, `itemUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:298](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/b6b1358/src/workbench-widget-api.ts#L298)*
+*Defined in [src/workbench-widget-api.ts:346](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L346)*
 
  Return concept details with preferred labels.
 
@@ -332,7 +362,7 @@ ___
 
 ▸ **getConceptRelated**(`taskGraphUri`: string, `itemUri`: string, `limit?`: number, `offset?`: number): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:320](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/b6b1358/src/workbench-widget-api.ts#L320)*
+*Defined in [src/workbench-widget-api.ts:368](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L368)*
 
  Return concept details with associative concepts grouped by relation type.
 
@@ -353,7 +383,7 @@ ___
 
 ▸ **getConceptSchemes**(`taskGraphUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:269](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/b6b1358/src/workbench-widget-api.ts#L269)*
+*Defined in [src/workbench-widget-api.ts:317](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L317)*
 
  Return all concept schemes for given task.
 
@@ -371,7 +401,7 @@ ___
 
 ▸ **getDetailsWithMetadata**(`taskGraphUri`: string, `itemUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:247](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/b6b1358/src/workbench-widget-api.ts#L247)*
+*Defined in [src/workbench-widget-api.ts:295](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L295)*
 
 Return Item with metadata properties.
 
@@ -390,7 +420,7 @@ ___
 
 ▸ **getMetadataForDomain**(`taskGraphUri`: string, `domainUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:258](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/b6b1358/src/workbench-widget-api.ts#L258)*
+*Defined in [src/workbench-widget-api.ts:306](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L306)*
 
  Return both default metadata and metadata specific for given domain.
 
@@ -409,7 +439,7 @@ ___
 
 ▸ **getMetadataTypes**(`taskGraphUri`: string, `itemUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:236](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/b6b1358/src/workbench-widget-api.ts#L236)*
+*Defined in [src/workbench-widget-api.ts:284](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L284)*
 
 Return Metadata types valid for item.
 
@@ -428,7 +458,7 @@ ___
 
 ▸ **getMetadataUnfilteredTypes**(`taskGraphUri`: string, `itemUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:225](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/b6b1358/src/workbench-widget-api.ts#L225)*
+*Defined in [src/workbench-widget-api.ts:273](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L273)*
 
 Return Metadata types.
 
@@ -447,7 +477,7 @@ ___
 
 ▸ **getModelLanguages**(`modelGraphUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:189](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/b6b1358/src/workbench-widget-api.ts#L189)*
+*Defined in [src/workbench-widget-api.ts:237](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L237)*
 
 Return Languages valid for the model.
 
@@ -465,7 +495,7 @@ ___
 
 ▸ **getNarrowerTypes**(`taskGraphUri`: string, `itemUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:178](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/b6b1358/src/workbench-widget-api.ts#L178)*
+*Defined in [src/workbench-widget-api.ts:226](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L226)*
 
 Return Narrower Types valid for current item.
 
@@ -484,7 +514,7 @@ ___
 
 ▸ **getNarrowerUnfilteredTypes**(`taskGraphUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:168](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/b6b1358/src/workbench-widget-api.ts#L168)*
+*Defined in [src/workbench-widget-api.ts:216](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L216)*
 
 Return all Narrower Types.
 
@@ -502,7 +532,7 @@ ___
 
 ▸ **getSemaphoreSettings**(`taskGraphUri`: string): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:196](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/b6b1358/src/workbench-widget-api.ts#L196)*
+*Defined in [src/workbench-widget-api.ts:244](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L244)*
 
 Return Semaphore Settings.
 
@@ -520,7 +550,7 @@ ___
 
 ▸ **getStateParams**(): Promise\<{ itemUri?: undefined \| string ; modelGraphUri?: undefined \| string ; taskGraphUri?: undefined \| string  }>
 
-*Defined in [src/workbench-widget-api.ts:78](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/b6b1358/src/workbench-widget-api.ts#L78)*
+*Defined in [src/workbench-widget-api.ts:126](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L126)*
 
 Fetch current host state params (modelGraphUri, taskGraphUri, itemUri).
 
@@ -532,7 +562,7 @@ ___
 
 ▸ **getTopConcepts**(`taskGraphUri`: string, `itemUri`: string, `limit?`: number, `offset?`: number): Promise\<unknown>
 
-*Defined in [src/workbench-widget-api.ts:374](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/b6b1358/src/workbench-widget-api.ts#L374)*
+*Defined in [src/workbench-widget-api.ts:422](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L422)*
 
  Return concept scheme details with top concepts.
 
@@ -553,7 +583,7 @@ ___
 
 ▸ **navigateToItem**(`item`: string): Promise\<void>
 
-*Defined in [src/workbench-widget-api.ts:91](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/b6b1358/src/workbench-widget-api.ts#L91)*
+*Defined in [src/workbench-widget-api.ts:139](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L139)*
 
 Navigate host application to item.
 
@@ -571,7 +601,7 @@ ___
 
 ▸ **openWidget**(`targetWidgetId`: string): Promise\<void>
 
-*Defined in [src/workbench-widget-api.ts:109](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/b6b1358/src/workbench-widget-api.ts#L109)*
+*Defined in [src/workbench-widget-api.ts:157](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L157)*
 
 Open different widget in the same model.
 
@@ -589,7 +619,7 @@ Name | Type |
 
 ▪  **actions**: object
 
-*Defined in [src/workbench-widget-api.ts:392](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/b6b1358/src/workbench-widget-api.ts#L392)*
+*Defined in [src/workbench-widget-api.ts:440](https://github.com/Smartlogic-Semaphore-Limited/Smartlogic-Semaphore-side-panel-widget-framework/blob/01d9094/src/workbench-widget-api.ts#L440)*
 
 Actions can be used to use Workbench functionality directly.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartlogic-semaphore/workbench-widget-api",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/workbench-widget-api.ts
+++ b/src/workbench-widget-api.ts
@@ -124,7 +124,7 @@ export class WorkbenchWidgetApi {
    */
   constructor(private readonly debug = false) {
     window.addEventListener("message", this._receiveMessage, false);
-    this._postMessage(this._createMessage(WIDGET_ID, "ready"));
+    this._postMessage(this._createMessage("ready"));
   }
 
   /**
@@ -145,7 +145,7 @@ export class WorkbenchWidgetApi {
    * Fetch current host state params (modelGraphUri, taskGraphUri, itemUri).
    */
   getStateParams() {
-    var message = this._createMessage(WIDGET_ID, "getStateParams");
+    var message = this._createMessage("getStateParams");
     return this._postMessage<{
       taskGraphUri?: string;
       modelGraphUri?: string;
@@ -158,7 +158,7 @@ export class WorkbenchWidgetApi {
    * @param item Item can be concept, concept scheme, relationship, class etc. existing in current task.
    */
   navigateToItem(item: string) {
-    var message = this._createMessage(WIDGET_ID, "navigateToItem", {
+    var message = this._createMessage("navigateToItem", {
       item,
     });
     return this._postMessage<void>(message);
@@ -168,7 +168,7 @@ export class WorkbenchWidgetApi {
    * Close right side panel in host application.
    */
   closeWidget() {
-    var message = this._createMessage(WIDGET_ID, "closeWidget");
+    var message = this._createMessage("closeWidget");
     return this._postMessage<void>(message);
   }
 
@@ -176,7 +176,7 @@ export class WorkbenchWidgetApi {
    * Open different widget in the same model.
    */
   openWidget(targetWidgetId: string) {
-    var message = this._createMessage(targetWidgetId, "openWidget");
+    var message = this._createMessage("openWidget", {}, targetWidgetId);
     return this._postMessage<void>(message);
   }
 
@@ -599,7 +599,7 @@ export class WorkbenchWidgetApi {
   };
 
   private _actionCall(action: string, data: object) {
-    const message = this._createMessage(WIDGET_ID, "callAction", {
+    const message = this._createMessage("callAction", {
       action,
       data,
     });
@@ -610,7 +610,7 @@ export class WorkbenchWidgetApi {
     backendFunction: string,
     backendArguments: { [key: string]: string | number | undefined }
   ) {
-    const message = this._createMessage(WIDGET_ID, "getBackendData", {
+    const message = this._createMessage("getBackendData", {
       backendFunction,
       backendArguments,
     });
@@ -679,9 +679,9 @@ export class WorkbenchWidgetApi {
     return WIDGET_ID + "_" + this._postIndex;
   }
   private _createMessage(
-    widgetId: string,
     key: string,
-    additionalData: SimpleObject = {}
+    additionalData: SimpleObject = {},
+    widgetId = WIDGET_ID
   ): Message {
     const tag = this._generateTag();
     return {

--- a/src/workbench-widget-api.ts
+++ b/src/workbench-widget-api.ts
@@ -1,11 +1,6 @@
 import { decycle, retrocycle } from "./cycle";
 
 /** @internal */
-const WIDGET_ID = decodeURIComponent(
-  window.location.hash.substr(1).replace(/^\//, "").replace(/\+/g, " ")
-);
-
-/** @internal */
 function hasOwnProperty<X extends {}, Y extends PropertyKey>(
   obj: X,
   prop: Y
@@ -115,6 +110,9 @@ type LabelEditFormData = {
  * @category Widget Api
  */
 export class WorkbenchWidgetApi {
+  private readonly WIDGET_ID = decodeURIComponent(
+    window.location.hash.substr(1).replace(/^\//, "").replace(/\+/g, " ")
+  );
   private _promises: Map<string, WaitForResponse> = new Map();
 
   private _eventListeners: Map<string, Set<EventListener>> = new Map();
@@ -676,12 +674,12 @@ export class WorkbenchWidgetApi {
   private _postIndex = 0;
   private _generateTag() {
     this._postIndex++;
-    return WIDGET_ID + "_" + this._postIndex;
+    return this.WIDGET_ID + "_" + this._postIndex;
   }
   private _createMessage(
     key: string,
     additionalData: SimpleObject = {},
-    widgetId = WIDGET_ID
+    widgetId = this.WIDGET_ID
   ): Message {
     const tag = this._generateTag();
     return {

--- a/test/main.js
+++ b/test/main.js
@@ -1,10 +1,16 @@
 describe("Unit tests: swApiWidget", () => {
   const widgetId = "widgetId";
   let widget;
+
+  function setupWidgetId(widgetId) {
+    window.location.hash = `#${widgetId}`;
+  }
+
   beforeEach(() => {
+    setupWidgetId(widgetId);
     spyOn(window.parent, "postMessage");
     spyOn(console, "error");
-    widget = new Semaphore.WorkbenchWidgetApi(widgetId);
+    widget = new Semaphore.WorkbenchWidgetApi();
   });
 
   it("getStateParams", function () {


### PR DESCRIPTION
Up till now widget API was only responsive - widget needed to ask for something and then would get a response.

With new events widget can now also register to events from KMM and any time a specific event occurs in KMM listeners will be informed about it.

Additionally with widgetId being not really configurable this parameter was removed from constructor. So it is breaking change in terms of API, but if anyone ever used it and passed custom widgetId their widget would not be working anyway.